### PR TITLE
CompatHelper: bump compat for NamedGraphs to 0.11, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorNetworksNext"
 uuid = "302f2e75-49f0-4526-aef7-d8ba550cb06c"
-version = "0.3.24"
+version = "0.3.25"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -47,7 +47,7 @@ Graphs = "1.13.1"
 LinearAlgebra = "1.10"
 MacroTools = "0.5.16"
 NamedDimsArrays = "0.14.2"
-NamedGraphs = "0.6.9, 0.7, 0.8"
+NamedGraphs = "0.6.9, 0.7, 0.8, 0.11"
 SimpleTraits = "0.9.5"
 SplitApplyCombine = "1.2.3"
 TensorOperations = "5.3.1"


### PR DESCRIPTION
This pull request changes the compat entry for the `NamedGraphs` package from `0.6.9, 0.7, 0.8` to `0.6.9, 0.7, 0.8, 0.11`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.