### PR TITLE
CompatHelper: bump compat for DataGraphs to 0.3, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorNetworksNext"
 uuid = "302f2e75-49f0-4526-aef7-d8ba550cb06c"
-version = "0.3.24"
+version = "0.3.25"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -39,7 +39,7 @@ Adapt = "4.3"
 AlgorithmsInterface = "0.1"
 BackendSelection = "0.1.6"
 Combinatorics = "1"
-DataGraphs = "0.2.7"
+DataGraphs = "0.2.7, 0.3"
 DiagonalArrays = "0.3.31"
 Dictionaries = "0.4.5"
 FunctionImplementations = "0.4"


### PR DESCRIPTION
This pull request changes the compat entry for the `DataGraphs` package from `0.2.7` to `0.2.7, 0.3`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.