### PR TITLE
CompatHelper: bump compat for NamedDimsArrays to 0.15, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorNetworksNext"
 uuid = "302f2e75-49f0-4526-aef7-d8ba550cb06c"
-version = "0.3.24"
+version = "0.3.25"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -46,7 +46,7 @@ FunctionImplementations = "0.4"
 Graphs = "1.13.1"
 LinearAlgebra = "1.10"
 MacroTools = "0.5.16"
-NamedDimsArrays = "0.14.2"
+NamedDimsArrays = "0.14.2, 0.15"
 NamedGraphs = "0.6.9, 0.7, 0.8"
 SimpleTraits = "0.9.5"
 SplitApplyCombine = "1.2.3"


### PR DESCRIPTION
This pull request changes the compat entry for the `NamedDimsArrays` package from `0.14.2` to `0.14.2, 0.15`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.